### PR TITLE
Fixed bug when two site extensions are transforming the same elements

### DIFF
--- a/build/RedirectHttpToHttps.nuspec
+++ b/build/RedirectHttpToHttps.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>RedirectHttpToHttps</id>
     <title>Redirect HTTP to HTTPS</title>
-    <version>0.0.1</version>
+    <version>0.1.0</version>
     <authors>gregjhogan</authors>
     <licenseUrl>http://opensource.org/licenses/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/gregjhogan/redirect-http-to-https-site-extension</projectUrl>

--- a/src/applicationhost.xdt
+++ b/src/applicationhost.xdt
@@ -4,7 +4,7 @@
         <system.webServer xdt:Transform="InsertIfMissing">
             <rewrite xdt:Transform="InsertIfMissing">
                 <rules xdt:Transform="InsertIfMissing" lockElements="clear">
-                    <rule name="redirect HTTP to HTTPS" enabled="true" stopProcessing="true" lockItem="true">
+                    <rule name="redirect HTTP to HTTPS" enabled="true" stopProcessing="true" lockItem="true" xdt:Transform="InsertIfMissing" xdt:Locator="Match(name)">
                         <match url="(.*)" />
                         <conditions>
                             <add input="{HTTPS}" pattern="off" ignoreCase="true" />


### PR DESCRIPTION
I'm also an author of Azure Site Extensions and I noticed an issue when your and my extensions were attempting to insert and/or update rewrite rules (instead of a merge of rules it appeared that the most recently-installed extension 'won' and only its rules ended up in the applicationHost file). I've made a change to my extension and pushed an update to the gallery, and here is the same fix for your extension - this lets the extensions coexist happily.